### PR TITLE
Add unified setup script and clean shell files

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")"
+
+# Run all setup scripts to prepare the environment
+./setup/system.sh
+./setup/ruby.sh
+./setup/node.sh
+# Uncomment if Python setup is needed
+# ./setup/python.sh
+
+npm install

--- a/setup/node.sh
+++ b/setup/node.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
-export NVM_DIR=$(pwd)/.nvm
+# Download and initialize a local copy of nvm and Node.js
+NVM_DIR="$(pwd)/.nvm"
+export NVM_DIR
 
 if ! [ -e "$NVM_DIR/installed" ];then
   rm -rf "$NVM_DIR"
@@ -8,8 +10,8 @@ fi
 if ! [ -e "$NVM_DIR" ];then
 #	(git clone https://github.com/creationix/nvm.git .nvm && cd .nvm && git checkout `git describe --abbrev=0 --tags`)
   echo "Downloading Node.JS to local directory"
-  (mkdir -p $NVM_DIR && cd .nvm && wget --quiet https://raw.githubusercontent.com/creationix/nvm/master/nvm.sh)
-	. .nvm/nvm.sh
+  (mkdir -p "$NVM_DIR" && cd .nvm && wget --quiet https://raw.githubusercontent.com/creationix/nvm/master/nvm.sh)
+  . .nvm/nvm.sh
   nvm install 0.10.32
   touch "$NVM_DIR/installed"
 fi

--- a/setup/python.sh
+++ b/setup/python.sh
@@ -1,4 +1,7 @@
-export PYENV_ROOT="$(pwd)/.pyenv"
+#!/bin/bash
+set -e
+PYENV_ROOT="$(pwd)/.pyenv"
+export PYENV_ROOT
 export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
 
 if ! [ -e "$PYENV_ROOT/installed" ];then
@@ -6,23 +9,23 @@ if ! [ -e "$PYENV_ROOT/installed" ];then
 fi
 
 if ! [ -e "$PYENV_ROOT" ];then
-	git clone git://github.com/yyuu/pyenv.git .pyenv
+        git clone git://github.com/yyuu/pyenv.git .pyenv
 	pyenv install 2.7.6
 	pyenv rehash
 	git clone https://github.com/yyuu/pyenv-virtualenv.git .pyenv/plugins/pyenv-virtualenv
-	pyenv virtualenv 2.7.6 virtkick
-	eval "$(pyenv init -)"
-	pyenv activate virtkick
-	cd .pyenv
-	wget ftp://xmlsoft.org/libxml2/libxml2-2.7.2.tar.gz
-	tar -xzvf libxml2-2.7.2.tar.gz
-	cd libxml2-2.7.2/
-	./configure --with-python=$(which python)
-	make -j4
-	cd python/
-	python setup.py install
-	cd ../../..
-	pip install libvirt-python==$LIBVIRT_VERSION
+        pyenv virtualenv 2.7.6 virtkick
+        eval "$(pyenv init -)"
+        pyenv activate virtkick
+        cd .pyenv || exit
+        wget ftp://xmlsoft.org/libxml2/libxml2-2.7.2.tar.gz
+        tar -xzvf libxml2-2.7.2.tar.gz
+        cd libxml2-2.7.2/ || exit
+        ./configure --with-python="$(which python)"
+        make -j4
+        cd python/ || exit
+        python setup.py install
+        cd ../../..
+        pip install "libvirt-python==$LIBVIRT_VERSION"
 	touch "$PYENV_ROOT/installed"
 else
 	eval "$(pyenv init -)"

--- a/setup/ruby.sh
+++ b/setup/ruby.sh
@@ -1,4 +1,7 @@
-export RVM_DIR="$(pwd)/.rvm"
+#!/bin/bash
+set -e
+RVM_DIR="$(pwd)/.rvm"
+export RVM_DIR
 
 if ! [ -e "$RVM_DIR/installed" ];then
   rm -rf "$RVM_DIR"
@@ -9,17 +12,14 @@ if ! [ -e "$RVM_DIR" ];then
 	mkdir -p "$RVM_DIR"
 	export rvm_user_install_flag=1
 	export rvm_path="$RVM_DIR"
-	curl -sSL https://get.rvm.io | bash -s -- --ignore-dotfiles #--autolibs=rvm_pkg
-	. .rvm/scripts/rvm
-  export PATH="$RVM_DIR/bin:$PATH"
+        curl -sSL https://get.rvm.io | bash -s -- --ignore-dotfiles #--autolibs=rvm_pkg
+        . .rvm/scripts/rvm
+        export PATH="$RVM_DIR/bin:$PATH"
 	rvm install 2.1.3
 	rvm alias create default 2.1.3
   touch "$RVM_DIR/installed"
 else
-	. .rvm/scripts/rvm
-	export PATH="$RVM_DIR/bin:$PATH"
+        . .rvm/scripts/rvm
+        export PATH="$RVM_DIR/bin:$PATH"
 fi
 which bundle > /dev/null
-
-
-

--- a/virtkick-start
+++ b/virtkick-start
@@ -1,20 +1,23 @@
 #!/bin/bash
 set -e
-cd $(dirname $0)
+cd "$(dirname "$0")"
 
 . setup/system.sh
 
 which virsh > /dev/null # should fail and exit script in case of missing
 
-export LIBVIRT_VERSION=$(virsh --version)
+LIBVIRT_VERSION=$(virsh --version)
+export LIBVIRT_VERSION
 
 if ! [ -e webapp/README.md ] || ! [ -e backend/README.md ];then
   echo "Pulling backend and webapp submodules"
   git submodule update --init --recursive
 fi
 
-export ISO_DIR="$(readlink -f ~virtkick)/iso"
-export HDD_DIR="$(readlink -f ~virtkick)/hdd"
+ISO_DIR="$(readlink -f ~virtkick)/iso"
+HDD_DIR="$(readlink -f ~virtkick)/hdd"
+export ISO_DIR
+export HDD_DIR
 
 . setup/ruby.sh
 
@@ -33,7 +36,7 @@ which pip > /dev/null || (echo "Command \"pip\" not found, please install python
 
 #. setup/python.sh
 
-node starter.js $*
+node starter.js "$@"
 
 # Remember error
 rc=$?


### PR DESCRIPTION
## Summary
- add `setup.sh` to streamline environment setup
- clean up shell scripts with proper shebangs and quoting
- improve `virtkick-start` argument handling

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684006956fb883209b51d5bf9add0b14